### PR TITLE
Introducing kg hub graphs

### DIFF
--- a/bindings/python/ensmallen_graph/datasets/__init__.py
+++ b/bindings/python/ensmallen_graph/datasets/__init__.py
@@ -1,7 +1,1 @@
-from .automatic_graphs import StringPPI, KGCOVID19, CompleteStringPPI
-
-__all__ = [
-    "StringPPI",
-    "KGCOVID19",
-    "CompleteStringPPI"
-]
+"""Module with datasets."""

--- a/bindings/python/ensmallen_graph/datasets/kg_hub.json
+++ b/bindings/python/ensmallen_graph/datasets/kg_hub.json
@@ -20,8 +20,8 @@
             "https://kg-hub.berkeleybop.io/kg-covid-19/current/transformed/GOCAMs/GOCAMs_nodes.tsv"
         ],
         "arguments": {
-            "edge_path": "edges.tsv",
-            "node_path": "nodes.tsv",
+            "edge_path": "GOCAMs_edges.tsv",
+            "node_path": "GOCAMs_nodes.tsv",
             "sources_column": "subject",
             "destinations_column": "object",
             "edge_types_column": "edge_label",

--- a/bindings/python/ensmallen_graph/datasets/kg_hub.json
+++ b/bindings/python/ensmallen_graph/datasets/kg_hub.json
@@ -1,0 +1,137 @@
+{
+    "ChEMBL": {
+        "urls": [
+            "https://kg-hub.berkeleybop.io/kg-covid-19/current/transformed/ChEMBL/edges.tsv",
+            "https://kg-hub.berkeleybop.io/kg-covid-19/current/transformed/ChEMBL/nodes.tsv"
+        ],
+        "arguments": {
+            "edge_path": "edges.tsv",
+            "node_path": "nodes.tsv",
+            "sources_column": "subject",
+            "destinations_column": "object",
+            "edge_types_column": "edge_label",
+            "nodes_column": "id",
+            "node_types_column": "category"
+        }
+    },
+    "GOCAMs": {
+        "urls": [
+            "https://kg-hub.berkeleybop.io/kg-covid-19/current/transformed/GOCAMs/GOCAMs_edges.tsv",
+            "https://kg-hub.berkeleybop.io/kg-covid-19/current/transformed/GOCAMs/GOCAMs_nodes.tsv"
+        ],
+        "arguments": {
+            "edge_path": "edges.tsv",
+            "node_path": "nodes.tsv",
+            "sources_column": "subject",
+            "destinations_column": "object",
+            "edge_types_column": "edge_label",
+            "nodes_column": "id",
+            "node_types_column": "category"
+        }
+    },
+    "STRING": {
+        "urls": [
+            "https://kg-hub.berkeleybop.io/kg-covid-19/current/transformed/STRING/edges.tsv",
+            "https://kg-hub.berkeleybop.io/kg-covid-19/current/transformed/STRING/nodes.tsv"
+        ],
+        "arguments": {
+            "edge_path": "edges.tsv",
+            "node_path": "nodes.tsv",
+            "sources_column": "subject",
+            "destinations_column": "object",
+            "edge_types_column": "edge_label",
+            "nodes_column": "id",
+            "node_types_column": "category"
+        }
+    },
+    "DrugCentral": {
+        "urls": [
+            "https://kg-hub.berkeleybop.io/kg-covid-19/current/transformed/drug_central/edges.tsv",
+            "https://kg-hub.berkeleybop.io/kg-covid-19/current/transformed/drug_central/nodes.tsv"
+        ],
+        "arguments": {
+            "edge_path": "edges.tsv",
+            "node_path": "nodes.tsv",
+            "sources_column": "subject",
+            "destinations_column": "object",
+            "edge_types_column": "edge_label",
+            "nodes_column": "id",
+            "node_types_column": "category"
+        }
+    },
+    "IntAct": {
+        "urls": [
+            "https://kg-hub.berkeleybop.io/kg-covid-19/current/transformed/intact/edges.tsv",
+            "https://kg-hub.berkeleybop.io/kg-covid-19/current/transformed/intact/nodes.tsv"
+        ],
+        "arguments": {
+            "edge_path": "edges.tsv",
+            "node_path": "nodes.tsv",
+            "sources_column": "subject",
+            "destinations_column": "object",
+            "edge_types_column": "edge_label",
+            "nodes_column": "id",
+            "node_types_column": "category"
+        }
+    },
+    "PharmGKB": {
+        "urls": [
+            "https://kg-hub.berkeleybop.io/kg-covid-19/current/transformed/pharmgkb/edges.tsv",
+            "https://kg-hub.berkeleybop.io/kg-covid-19/current/transformed/pharmgkb/nodes.tsv"
+        ],
+        "arguments": {
+            "edge_path": "edges.tsv",
+            "node_path": "nodes.tsv",
+            "sources_column": "subject",
+            "destinations_column": "object",
+            "edge_types_column": "edge_label",
+            "nodes_column": "id",
+            "node_types_column": "category"
+        }
+    },
+    "SARSCOV2GeneAnnot": {
+        "urls": [
+            "https://kg-hub.berkeleybop.io/kg-covid-19/current/transformed/sars_cov_2_gene_annot/edges.tsv",
+            "https://kg-hub.berkeleybop.io/kg-covid-19/current/transformed/sars_cov_2_gene_annot/nodes.tsv"
+        ],
+        "arguments": {
+            "edge_path": "edges.tsv",
+            "node_path": "nodes.tsv",
+            "sources_column": "subject",
+            "destinations_column": "object",
+            "edge_types_column": "edge_label",
+            "nodes_column": "id",
+            "node_types_column": "category"
+        }
+    },
+    "ZhouHostProteins": {
+        "urls": [
+            "https://kg-hub.berkeleybop.io/kg-covid-19/current/transformed/zhou_host_proteins/edges.tsv",
+            "https://kg-hub.berkeleybop.io/kg-covid-19/current/transformed/zhou_host_proteins/nodes.tsv"
+        ],
+        "arguments": {
+            "edge_path": "edges.tsv",
+            "node_path": "nodes.tsv",
+            "sources_column": "subject",
+            "destinations_column": "object",
+            "edge_types_column": "edge_label",
+            "nodes_column": "id",
+            "node_types_column": "category"
+        }
+    },
+    "KG-COVID19": {
+        "urls": [
+            "https://kg-hub.berkeleybop.io/kg-covid-19/current/kg-covid-19.tar.gz"
+        ],
+        "arguments": {
+            "edge_path": "kg-covid-19/merged-kg_edges.tsv",
+            "node_path": "kg-covid-19/merged-kg_nodes.tsv",
+            "sources_column": "subject",
+            "destinations_column": "object",
+            "edge_types_column": "edge_label",
+            "nodes_column": "id",
+            "node_types_column": "category",
+            "default_node_type": "biolink:NamedThing"
+        }
+    }
+}

--- a/bindings/python/ensmallen_graph/datasets/kg_hub.py
+++ b/bindings/python/ensmallen_graph/datasets/kg_hub.py
@@ -33,7 +33,8 @@ def KGCOVID19(
         "KG-COVID19",
         directed=directed,
         verbose=verbose,
-        cache_path=cache_path
+        cache_path=cache_path,
+        dataset="kg_hub"
     )()
 
 
@@ -64,7 +65,8 @@ def ChEMBL(
         "ChEMBL",
         directed=directed,
         verbose=verbose,
-        cache_path=cache_path
+        cache_path=cache_path,
+        dataset="kg_hub"
     )()
 
 
@@ -95,7 +97,8 @@ def GOCAMs(
         "GOCAMs",
         directed=directed,
         verbose=verbose,
-        cache_path=cache_path
+        cache_path=cache_path,
+        dataset="kg_hub"
     )()
 
 
@@ -126,7 +129,8 @@ def STRING(
         "STRING",
         directed=directed,
         verbose=verbose,
-        cache_path=cache_path
+        cache_path=cache_path,
+        dataset="kg_hub"
     )()
 
 
@@ -157,7 +161,8 @@ def DrugCentral(
         "DrugCentral",
         directed=directed,
         verbose=verbose,
-        cache_path=cache_path
+        cache_path=cache_path,
+        dataset="kg_hub"
     )()
 
 
@@ -188,7 +193,8 @@ def IntAct(
         "IntAct",
         directed=directed,
         verbose=verbose,
-        cache_path=cache_path
+        cache_path=cache_path,
+        dataset="kg_hub"
     )()
 
 
@@ -219,7 +225,8 @@ def PharmGKB(
         "PharmGKB",
         directed=directed,
         verbose=verbose,
-        cache_path=cache_path
+        cache_path=cache_path,
+        dataset="kg_hub"
     )()
 
 
@@ -250,7 +257,8 @@ def SARSCOV2GeneAnnot(
         "SARSCOV2GeneAnnot",
         directed=directed,
         verbose=verbose,
-        cache_path=cache_path
+        cache_path=cache_path,
+        dataset="kg_hub"
     )()
 
 
@@ -281,5 +289,6 @@ def ZhouHostProteins(
         "ZhouHostProteins",
         directed=directed,
         verbose=verbose,
-        cache_path=cache_path
+        cache_path=cache_path,
+        dataset="kg_hub"
     )()

--- a/bindings/python/ensmallen_graph/datasets/kg_hub.py
+++ b/bindings/python/ensmallen_graph/datasets/kg_hub.py
@@ -1,0 +1,285 @@
+from .automatic_graph_retrieval import AutomaticallyRetrievedGraph
+from ..ensmallen_graph import EnsmallenGraph  # pylint: disable=import-error
+
+
+def KGCOVID19(
+    directed: bool = False,
+    verbose: int = 2,
+    cache_path: str = "graphs"
+) -> EnsmallenGraph:
+    """Return new instance of the KG-COVID19 graph.
+
+    TODO: Further describe the graph!
+
+    Parameters
+    -------------------
+    directed: bool = False,
+        Wether to load the graph as directed or undirected.
+        By default false.
+    verbose: int = 2,
+        Wether to show loading bars.
+    cache_path: str = "graphs",
+        Where to store the downloaded graphs.
+
+    Returns
+    -----------------------
+    Instace of KG-COVID graph.
+
+    References
+    -----------------------
+    https://www.cell.com/patterns/pdf/S2666-3899(20)30203-8.pdf
+    """
+    return AutomaticallyRetrievedGraph(
+        "KG-COVID19",
+        directed=directed,
+        verbose=verbose,
+        cache_path=cache_path
+    )()
+
+
+def ChEMBL(
+    directed: bool = False,
+    verbose: int = 2,
+    cache_path: str = "graphs"
+) -> EnsmallenGraph:
+    """Return new instance of the ChEMBL graph.
+
+    TODO: Further describe the graph!
+
+    Parameters
+    -------------------
+    directed: bool = False,
+        Wether to load the graph as directed or undirected.
+        By default false.
+    verbose: int = 2,
+        Wether to show loading bars.
+    cache_path: str = "graphs",
+        Where to store the downloaded graphs.
+
+    Returns
+    -----------------------
+    Instace of ChEMBL graph.
+    """
+    return AutomaticallyRetrievedGraph(
+        "ChEMBL",
+        directed=directed,
+        verbose=verbose,
+        cache_path=cache_path
+    )()
+
+
+def GOCAMs(
+    directed: bool = False,
+    verbose: int = 2,
+    cache_path: str = "graphs"
+) -> EnsmallenGraph:
+    """Return new instance of the GOCAMs graph.
+
+    TODO: Further describe the graph!
+
+    Parameters
+    -------------------
+    directed: bool = False,
+        Wether to load the graph as directed or undirected.
+        By default false.
+    verbose: int = 2,
+        Wether to show loading bars.
+    cache_path: str = "graphs",
+        Where to store the downloaded graphs.
+
+    Returns
+    -----------------------
+    Instace of GOCAMs graph.
+    """
+    return AutomaticallyRetrievedGraph(
+        "GOCAMs",
+        directed=directed,
+        verbose=verbose,
+        cache_path=cache_path
+    )()
+
+
+def STRING(
+    directed: bool = False,
+    verbose: int = 2,
+    cache_path: str = "graphs"
+) -> EnsmallenGraph:
+    """Return new instance of the STRING graph.
+
+    TODO: Further describe the graph!
+
+    Parameters
+    -------------------
+    directed: bool = False,
+        Wether to load the graph as directed or undirected.
+        By default false.
+    verbose: int = 2,
+        Wether to show loading bars.
+    cache_path: str = "graphs",
+        Where to store the downloaded graphs.
+
+    Returns
+    -----------------------
+    Instace of STRING graph.
+    """
+    return AutomaticallyRetrievedGraph(
+        "STRING",
+        directed=directed,
+        verbose=verbose,
+        cache_path=cache_path
+    )()
+
+
+def DrugCentral(
+    directed: bool = False,
+    verbose: int = 2,
+    cache_path: str = "graphs"
+) -> EnsmallenGraph:
+    """Return new instance of the DrugCentral graph.
+
+    TODO: Further describe the graph!
+
+    Parameters
+    -------------------
+    directed: bool = False,
+        Wether to load the graph as directed or undirected.
+        By default false.
+    verbose: int = 2,
+        Wether to show loading bars.
+    cache_path: str = "graphs",
+        Where to store the downloaded graphs.
+
+    Returns
+    -----------------------
+    Instace of DrugCentral graph.
+    """
+    return AutomaticallyRetrievedGraph(
+        "DrugCentral",
+        directed=directed,
+        verbose=verbose,
+        cache_path=cache_path
+    )()
+
+
+def IntAct(
+    directed: bool = False,
+    verbose: int = 2,
+    cache_path: str = "graphs"
+) -> EnsmallenGraph:
+    """Return new instance of the IntAct graph.
+
+    TODO: Further describe the graph!
+
+    Parameters
+    -------------------
+    directed: bool = False,
+        Wether to load the graph as directed or undirected.
+        By default false.
+    verbose: int = 2,
+        Wether to show loading bars.
+    cache_path: str = "graphs",
+        Where to store the downloaded graphs.
+
+    Returns
+    -----------------------
+    Instace of IntAct graph.
+    """
+    return AutomaticallyRetrievedGraph(
+        "IntAct",
+        directed=directed,
+        verbose=verbose,
+        cache_path=cache_path
+    )()
+
+
+def PharmGKB(
+    directed: bool = False,
+    verbose: int = 2,
+    cache_path: str = "graphs"
+) -> EnsmallenGraph:
+    """Return new instance of the PharmGKB graph.
+
+    TODO: Further describe the graph!
+
+    Parameters
+    -------------------
+    directed: bool = False,
+        Wether to load the graph as directed or undirected.
+        By default false.
+    verbose: int = 2,
+        Wether to show loading bars.
+    cache_path: str = "graphs",
+        Where to store the downloaded graphs.
+
+    Returns
+    -----------------------
+    Instace of PharmGKB graph.
+    """
+    return AutomaticallyRetrievedGraph(
+        "PharmGKB",
+        directed=directed,
+        verbose=verbose,
+        cache_path=cache_path
+    )()
+
+
+def SARSCOV2GeneAnnot(
+    directed: bool = False,
+    verbose: int = 2,
+    cache_path: str = "graphs"
+) -> EnsmallenGraph:
+    """Return new instance of the SARSCOV2GeneAnnot graph.
+
+    TODO: Further describe the graph!
+
+    Parameters
+    -------------------
+    directed: bool = False,
+        Wether to load the graph as directed or undirected.
+        By default false.
+    verbose: int = 2,
+        Wether to show loading bars.
+    cache_path: str = "graphs",
+        Where to store the downloaded graphs.
+
+    Returns
+    -----------------------
+    Instace of SARSCOV2GeneAnnot graph.
+    """
+    return AutomaticallyRetrievedGraph(
+        "SARSCOV2GeneAnnot",
+        directed=directed,
+        verbose=verbose,
+        cache_path=cache_path
+    )()
+
+
+def ZhouHostProteins(
+    directed: bool = False,
+    verbose: int = 2,
+    cache_path: str = "graphs"
+) -> EnsmallenGraph:
+    """Return new instance of the ZhouHostProteins graph.
+
+    TODO: Further describe the graph!
+
+    Parameters
+    -------------------
+    directed: bool = False,
+        Wether to load the graph as directed or undirected.
+        By default false.
+    verbose: int = 2,
+        Wether to show loading bars.
+    cache_path: str = "graphs",
+        Where to store the downloaded graphs.
+
+    Returns
+    -----------------------
+    Instace of ZhouHostProteins graph.
+    """
+    return AutomaticallyRetrievedGraph(
+        "ZhouHostProteins",
+        directed=directed,
+        verbose=verbose,
+        cache_path=cache_path
+    )()

--- a/bindings/python/ensmallen_graph/datasets/string.json
+++ b/bindings/python/ensmallen_graph/datasets/string.json
@@ -1,5 +1,5 @@
 {
-    "StringPPI": {
+    "HumanString": {
         "urls": [
             "https://stringdb-static.org/download/protein.actions.v11.0/9606.protein.actions.v11.0.txt.gz"
         ],
@@ -11,7 +11,7 @@
             "weights_column": "score"
         }
     },
-    "CompleteStringPPI": {
+    "CompleteString": {
         "urls": [
             "https://stringdb-static.org/download/protein.links.v11.0.txt.gz"
         ],
@@ -21,21 +21,6 @@
             "destinations_column": "protein2",
             "edge_separator": " ",
             "weights_column": "combined_score"
-        }
-    },
-    "KG-COVID19": {
-        "urls": [
-            "https://kg-hub.berkeleybop.io/kg-covid-19/current/kg-covid-19.tar.gz"
-        ],
-        "arguments": {
-            "edge_path": "kg-covid-19/merged-kg_edges.tsv",
-            "node_path": "kg-covid-19/merged-kg_nodes.tsv",
-            "sources_column": "subject",
-            "destinations_column": "object",
-            "edge_types_column": "edge_label",
-            "nodes_column": "id",
-            "node_types_column": "category",
-            "default_node_type": "biolink:NamedThing"
         }
     }
 }

--- a/bindings/python/ensmallen_graph/datasets/string.py
+++ b/bindings/python/ensmallen_graph/datasets/string.py
@@ -3,7 +3,7 @@ from ..ensmallen_graph import EnsmallenGraph  # pylint: disable=import-error
 from .automatic_graph_retrieval import AutomaticallyRetrievedGraph
 
 
-def String(
+def HumanString(
     directed: bool = False,
     verbose: int = 2,
     cache_path: str = "graphs"
@@ -28,7 +28,7 @@ def String(
     String PPI graph.
     """
     return AutomaticallyRetrievedGraph(
-        "String",
+        "HumanString",
         directed=directed,
         verbose=verbose,
         cache_path=cache_path,

--- a/bindings/python/ensmallen_graph/datasets/string.py
+++ b/bindings/python/ensmallen_graph/datasets/string.py
@@ -3,12 +3,12 @@ from ..ensmallen_graph import EnsmallenGraph  # pylint: disable=import-error
 from .automatic_graph_retrieval import AutomaticallyRetrievedGraph
 
 
-def StringPPI(
+def String(
     directed: bool = False,
     verbose: int = 2,
     cache_path: str = "graphs"
 ) -> EnsmallenGraph:
-    """Return new instance of the human StringPPI graph (not filtered).
+    """Return new instance of the human String graph (not filtered).
 
     The retrieved graph is automatically retrieved directly from the STRING
     website, that is https://string-db.org/.
@@ -28,18 +28,19 @@ def StringPPI(
     String PPI graph.
     """
     return AutomaticallyRetrievedGraph(
-        "StringPPI",
+        "String",
         directed=directed,
         verbose=verbose,
         cache_path=cache_path
     )()
 
-def CompleteStringPPI(
+
+def CompleteString(
     directed: bool = False,
     verbose: int = 2,
     cache_path: str = "graphs"
 ) -> EnsmallenGraph:
-    """Return new instance of the Complete (cross-species) StringPPI graph (not filtered).
+    """Return new instance of the Complete (cross-species) String graph (not filtered).
 
     THIS GRAPH IS VERY VERY BIG, ABOUT 43GB!
 
@@ -58,42 +59,10 @@ def CompleteStringPPI(
 
     Returns
     -----------------------
-    String PPI graph.
+    String  graph.
     """
     return AutomaticallyRetrievedGraph(
-        "CompleteStringPPI",
-        directed=directed,
-        verbose=verbose,
-        cache_path=cache_path
-    )()
-
-
-def KGCOVID19(
-    directed: bool = False,
-    verbose: int = 2,
-    cache_path: str = "graphs"
-) -> EnsmallenGraph:
-    """Return new instance of the KG-COVID19 graph.
-
-    The retrieved graph is automatically retrieved directly from the STRING
-    website, that is https://string-db.org/.
-
-    Parameters
-    -------------------
-    directed: bool = False,
-        Wether to load the graph as directed or undirected.
-        By default false.
-    verbose: int = 2,
-        Wether to show loading bars.
-    cache_path: str = "graphs",
-        Where to store the downloaded graphs.
-
-    Returns
-    -----------------------
-    String PPI graph.
-    """
-    return AutomaticallyRetrievedGraph(
-        "KG-COVID19",
+        "CompleteString",
         directed=directed,
         verbose=verbose,
         cache_path=cache_path

--- a/bindings/python/ensmallen_graph/datasets/string.py
+++ b/bindings/python/ensmallen_graph/datasets/string.py
@@ -31,7 +31,8 @@ def String(
         "String",
         directed=directed,
         verbose=verbose,
-        cache_path=cache_path
+        cache_path=cache_path,
+        dataset="string"
     )()
 
 
@@ -65,5 +66,6 @@ def CompleteString(
         "CompleteString",
         directed=directed,
         verbose=verbose,
-        cache_path=cache_path
+        cache_path=cache_path,
+        dataset="string"
     )()

--- a/graph/src/walks.rs
+++ b/graph/src/walks.rs
@@ -2,7 +2,7 @@ use super::*;
 use log::info;
 use rayon::prelude::*;
 use vec_rand::sample_f32 as sample;
-use vec_rand::sample_k_distinct_uniform;
+use vec_rand::sorted_unique_sub_sampling;
 use vec_rand::sample_uniform;
 use vec_rand::xorshift::xorshift;
 
@@ -306,7 +306,7 @@ fn get_probabilistic_indices(
     if let Some(mn) = max_neighbours {
         if (*mn as u64) < (max_edge_id - min_edge_id) {
             return Some(
-                sample_k_distinct_uniform(
+                sorted_unique_sub_sampling(
                     min_edge_id,
                     max_edge_id,
                     *mn as u64,

--- a/notebooks_and_scripts/Automatic retrieval of graphs from KG-Hub.ipynb
+++ b/notebooks_and_scripts/Automatic retrieval of graphs from KG-Hub.ipynb
@@ -1,0 +1,361 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from ensmallen_graph.datasets.kg_hub import STRING\n",
+    "from ensmallen_graph.datasets.kg_hub import ChEMBL\n",
+    "from ensmallen_graph.datasets.kg_hub import DrugCentral\n",
+    "from ensmallen_graph.datasets.kg_hub import GOCAMs\n",
+    "from ensmallen_graph.datasets.kg_hub import IntAct\n",
+    "from ensmallen_graph.datasets.kg_hub import PharmGKB\n",
+    "from ensmallen_graph.datasets.kg_hub import SARSCOV2GeneAnnot\n",
+    "from ensmallen_graph.datasets.kg_hub import ZhouHostProteins\n",
+    "from ensmallen_graph.datasets.kg_hub import KGCOVID19"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(HTML(value='Downloading files'), FloatProgress(value=0.0, layout=Layout(flex='2'), max=2.0), HT…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<p style=\"text-align: justify; text-justify: inter-word;\">The undirected graph STRING has 37020 nodes with 2 different node types: biolink:Protein (nodes number 19354) and biolink:Gene (nodes number 17666) and 5897393 unweighted edges with 2 different edge types: biolink:interacts_with and biolink:has_gene_product, of which none are self-loops. The graph is sparse as it has a density of 0.00861 and is connected, as it has a single component. The graph median node degree is 62, the mean node degree is 318.61 and the node degree mode is 1. The top 5 most central nodes are ENSEMBL:ENSP00000229239 (degree 7646), ENSEMBL:ENSP00000451828 (degree 6508), ENSEMBL:ENSP00000269305 (degree 6197), ENSEMBL:ENSP00000380432 (degree 6055) and ENSEMBL:ENSP00000479618 (degree 5787).</p>"
+      ],
+      "text/plain": [
+       "The undirected graph STRING has 37020 nodes with 2 different node types: biolink:Protein (nodes number 19354) and biolink:Gene (nodes number 17666) and 5897393 unweighted edges with 2 different edge types: biolink:interacts_with and biolink:has_gene_product, of which none are self-loops. The graph is sparse as it has a density of 0.00861 and is connected, as it has a single component. The graph median node degree is 62, the mean node degree is 318.61 and the node degree mode is 1. The top 5 most central nodes are ENSEMBL:ENSP00000229239 (degree 7646), ENSEMBL:ENSP00000451828 (degree 6508), ENSEMBL:ENSP00000269305 (degree 6197), ENSEMBL:ENSP00000380432 (degree 6055) and ENSEMBL:ENSP00000479618 (degree 5787)."
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "STRING()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(HTML(value='Downloading files'), FloatProgress(value=0.0, layout=Layout(flex='2'), max=2.0), HT…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "ename": "ValueError",
+     "evalue": "In the edge file was found the node NCBITaxon:2697049 which is not present in the given node file.",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mValueError\u001b[0m                                Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-3-b704ff7be83a>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0mChEMBL\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[0;32m/usr/local/lib/python3.6/dist-packages/ensmallen_graph/datasets/kg_hub.py\u001b[0m in \u001b[0;36mChEMBL\u001b[0;34m(directed, verbose, cache_path)\u001b[0m\n\u001b[1;32m     67\u001b[0m         \u001b[0mverbose\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mverbose\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     68\u001b[0m         \u001b[0mcache_path\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mcache_path\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 69\u001b[0;31m         \u001b[0mdataset\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m\"kg_hub\"\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     70\u001b[0m     )()\n\u001b[1;32m     71\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m/usr/local/lib/python3.6/dist-packages/ensmallen_graph/datasets/automatic_graph_retrieval.py\u001b[0m in \u001b[0;36m__call__\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m     69\u001b[0m             \u001b[0mdirected\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_directed\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     70\u001b[0m             \u001b[0mverbose\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_verbose\u001b[0m \u001b[0;34m>\u001b[0m \u001b[0;36m0\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 71\u001b[0;31m             \u001b[0mname\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_name\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     72\u001b[0m         )\n",
+      "\u001b[0;31mValueError\u001b[0m: In the edge file was found the node NCBITaxon:2697049 which is not present in the given node file."
+     ]
+    }
+   ],
+   "source": [
+    "ChEMBL()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(HTML(value='Downloading files'), FloatProgress(value=0.0, layout=Layout(flex='2'), max=2.0), HT…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<p style=\"text-align: justify; text-justify: inter-word;\">The undirected graph DrugCentral has 3753 nodes with 2 different node types: biolink:Drug (nodes number 2211) and biolink:Protein (nodes number 1542) and 13900 unweighted edges with a single edge type: biolink:molecularly_interacts_with, of which none are self-loops. The graph is sparse as it has a density of 0.00197 and has 118 connected components, where the component with most nodes has 3343 nodes and the component with the least nodes has 2 nodes. The graph median node degree is 3, the mean node degree is 7.41 and the node degree mode is 1. The top 5 most central nodes are DrugCentral:2544 (degree 263), DrugCentral:4903 (degree 218), DrugCentral:5231 (degree 203), DrugCentral:4359 (degree 199) and UniProtKB:P28223 (degree 174).</p>"
+      ],
+      "text/plain": [
+       "The undirected graph DrugCentral has 3753 nodes with 2 different node types: biolink:Drug (nodes number 2211) and biolink:Protein (nodes number 1542) and 13900 unweighted edges with a single edge type: biolink:molecularly_interacts_with, of which none are self-loops. The graph is sparse as it has a density of 0.00197 and has 118 connected components, where the component with most nodes has 3343 nodes and the component with the least nodes has 2 nodes. The graph median node degree is 3, the mean node degree is 7.41 and the node degree mode is 1. The top 5 most central nodes are DrugCentral:2544 (degree 263), DrugCentral:4903 (degree 218), DrugCentral:5231 (degree 203), DrugCentral:4359 (degree 199) and UniProtKB:P28223 (degree 174)."
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "DrugCentral()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(HTML(value='Downloading files'), FloatProgress(value=0.0, layout=Layout(flex='2'), max=2.0), HT…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<p style=\"text-align: justify; text-justify: inter-word;\">The undirected multigraph GOCAMs has 3681 nodes with a single node type: biolink:NamedThing (nodes number 3681), of which 47 are singletons (all have self-loops), and 3598 unweighted edges with 10 different edge types:  the 5 most common are biolink:related_to, biolink:negatively_regulates_process_to_process, biolink:part_of, biolink:enabled_by and biolink:has_input, of which 234 are self-loops and 31 are parallel. The graph is quite sparse as it has a density of 0.00051 and has 766 connected components, where the component with most nodes has 510 nodes and the component with the least nodes has a single node. The graph median node degree is 1, the mean node degree is 1.89 and the node degree mode is 1. The top 5 most central nodes are REACT:R-HSA-68819 (degree 34), MGI:MGI:95809 (degree 25), REACT:R-HSA-5693527 (degree 21), REACT:R-HSA-1442481 (degree 18) and REACT:R-HSA-2537512 (degree 18).</p>"
+      ],
+      "text/plain": [
+       "The undirected multigraph GOCAMs has 3681 nodes with a single node type: biolink:NamedThing (nodes number 3681), of which 47 are singletons (all have self-loops), and 3598 unweighted edges with 10 different edge types:  the 5 most common are biolink:related_to, biolink:negatively_regulates_process_to_process, biolink:part_of, biolink:enabled_by and biolink:has_input, of which 234 are self-loops and 31 are parallel. The graph is quite sparse as it has a density of 0.00051 and has 766 connected components, where the component with most nodes has 510 nodes and the component with the least nodes has a single node. The graph median node degree is 1, the mean node degree is 1.89 and the node degree mode is 1. The top 5 most central nodes are REACT:R-HSA-68819 (degree 34), MGI:MGI:95809 (degree 25), REACT:R-HSA-5693527 (degree 21), REACT:R-HSA-1442481 (degree 18) and REACT:R-HSA-2537512 (degree 18)."
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "GOCAMs()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(HTML(value='Downloading files'), FloatProgress(value=0.0, layout=Layout(flex='2'), max=2.0), HT…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<p style=\"text-align: justify; text-justify: inter-word;\">The undirected graph IntAct has 3058 nodes with 4 different node types: biolink:Protein (nodes number 2945), biolink:Drug (nodes number 82), biolink:RNA (nodes number 28) and biolink:MolecularEntity (nodes number 3), of which 2265 are singletons (2 of these have self-loops), and 1167 unweighted edges with a single edge type: biolink:interacts_with, of which 35 are self-loops. The graph is quite sparse as it has a density of 0.00025 and has 2310 connected components, where the component with most nodes has 603 nodes and the component with the least nodes has a single node. The graph median node degree is 0, the mean node degree is 0.75 and the node degree mode is 0. The top 5 most central nodes are UniProtKB:P0DTC2 (degree 59), UniProtKB:Q14160 (degree 53), UniProtKB:Q12959 (degree 53), UniProtKB:P0C6X7-PRO_0000037311 (degree 34) and UniProtKB:Q9BYF1 (degree 31).</p>"
+      ],
+      "text/plain": [
+       "The undirected graph IntAct has 3058 nodes with 4 different node types: biolink:Protein (nodes number 2945), biolink:Drug (nodes number 82), biolink:RNA (nodes number 28) and biolink:MolecularEntity (nodes number 3), of which 2265 are singletons (2 of these have self-loops), and 1167 unweighted edges with a single edge type: biolink:interacts_with, of which 35 are self-loops. The graph is quite sparse as it has a density of 0.00025 and has 2310 connected components, where the component with most nodes has 603 nodes and the component with the least nodes has a single node. The graph median node degree is 0, the mean node degree is 0.75 and the node degree mode is 0. The top 5 most central nodes are UniProtKB:P0DTC2 (degree 59), UniProtKB:Q14160 (degree 53), UniProtKB:Q12959 (degree 53), UniProtKB:P0C6X7-PRO_0000037311 (degree 34) and UniProtKB:Q9BYF1 (degree 31)."
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "IntAct()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(HTML(value='Downloading files'), FloatProgress(value=0.0, layout=Layout(flex='2'), max=2.0), HT…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<p style=\"text-align: justify; text-justify: inter-word;\">The undirected graph PharmGKB has 2453 nodes with 2 different node types: biolink:Gene (nodes number 1326) and biolink:Drug (nodes number 1127) and 5720 unweighted edges with a single edge type: biolink:interacts_with, of which none are self-loops. The graph is sparse as it has a density of 0.00190 and has 35 connected components, where the component with most nodes has 2370 nodes and the component with the least nodes has 2 nodes. The graph median node degree is 2, the mean node degree is 4.66 and the node degree mode is 1. The top 5 most central nodes are UniProtKB:P08183 (degree 218), UniProtKB:Q6GRK0 (degree 180), UniProtKB:Q6NXU8 (degree 178), UniProtKB:P33261 (degree 119) and UniProtKB:P20815 (degree 107).</p>"
+      ],
+      "text/plain": [
+       "The undirected graph PharmGKB has 2453 nodes with 2 different node types: biolink:Gene (nodes number 1326) and biolink:Drug (nodes number 1127) and 5720 unweighted edges with a single edge type: biolink:interacts_with, of which none are self-loops. The graph is sparse as it has a density of 0.00190 and has 35 connected components, where the component with most nodes has 2370 nodes and the component with the least nodes has 2 nodes. The graph median node degree is 2, the mean node degree is 4.66 and the node degree mode is 1. The top 5 most central nodes are UniProtKB:P08183 (degree 218), UniProtKB:Q6GRK0 (degree 180), UniProtKB:Q6NXU8 (degree 178), UniProtKB:P33261 (degree 119) and UniProtKB:P20815 (degree 107)."
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "PharmGKB()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(HTML(value='Downloading files'), FloatProgress(value=0.0, layout=Layout(flex='2'), max=2.0), HT…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "ename": "ValueError",
+     "evalue": "Found empty node type but no default node type to use was provided. The node name is UniProtKB:A0A679G4B7.\nThe path of the document was graphs/SARSCOV2GeneAnnot/nodes.tsv.\n",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mValueError\u001b[0m                                Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-8-589dc59bc4bd>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0mSARSCOV2GeneAnnot\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[0;32m/usr/local/lib/python3.6/dist-packages/ensmallen_graph/datasets/kg_hub.py\u001b[0m in \u001b[0;36mSARSCOV2GeneAnnot\u001b[0;34m(directed, verbose, cache_path)\u001b[0m\n\u001b[1;32m    259\u001b[0m         \u001b[0mverbose\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mverbose\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    260\u001b[0m         \u001b[0mcache_path\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mcache_path\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 261\u001b[0;31m         \u001b[0mdataset\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m\"kg_hub\"\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    262\u001b[0m     )()\n\u001b[1;32m    263\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m/usr/local/lib/python3.6/dist-packages/ensmallen_graph/datasets/automatic_graph_retrieval.py\u001b[0m in \u001b[0;36m__call__\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m     69\u001b[0m             \u001b[0mdirected\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_directed\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     70\u001b[0m             \u001b[0mverbose\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_verbose\u001b[0m \u001b[0;34m>\u001b[0m \u001b[0;36m0\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 71\u001b[0;31m             \u001b[0mname\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_name\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     72\u001b[0m         )\n",
+      "\u001b[0;31mValueError\u001b[0m: Found empty node type but no default node type to use was provided. The node name is UniProtKB:A0A679G4B7.\nThe path of the document was graphs/SARSCOV2GeneAnnot/nodes.tsv.\n"
+     ]
+    }
+   ],
+   "source": [
+    "SARSCOV2GeneAnnot()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(HTML(value='Downloading files'), FloatProgress(value=0.0, layout=Layout(flex='2'), max=2.0), HT…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<p style=\"text-align: justify; text-justify: inter-word;\">The undirected graph ZhouHostProteins has 125 nodes with 2 different node types: biolink:Gene (nodes number 119) and biolink:OrganismalEntity (nodes number 6) and 127 unweighted edges with a single edge type: biolink:interacts_with, of which none are self-loops. The graph is dense as it has a density of 0.01639 and has 2 connected components, where the component with most nodes has 118 nodes and the component with the least nodes has 7 nodes. The graph median node degree is 1, the mean node degree is 2.03 and the node degree mode is 1. The top 5 most central nodes are NCBITaxon:227859 (degree 64), NCBITaxon:502104 (degree 37), NCBITaxon:11120 (degree 16), NCBITaxon:1335626 (degree 6) and NCBITaxon:11137 (degree 3).</p>"
+      ],
+      "text/plain": [
+       "The undirected graph ZhouHostProteins has 125 nodes with 2 different node types: biolink:Gene (nodes number 119) and biolink:OrganismalEntity (nodes number 6) and 127 unweighted edges with a single edge type: biolink:interacts_with, of which none are self-loops. The graph is dense as it has a density of 0.01639 and has 2 connected components, where the component with most nodes has 118 nodes and the component with the least nodes has 7 nodes. The graph median node degree is 1, the mean node degree is 2.03 and the node degree mode is 1. The top 5 most central nodes are NCBITaxon:227859 (degree 64), NCBITaxon:502104 (degree 37), NCBITaxon:11120 (degree 16), NCBITaxon:1335626 (degree 6) and NCBITaxon:11137 (degree 3)."
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ZhouHostProteins()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<p style=\"text-align: justify; text-justify: inter-word;\">The undirected multigraph KG-COVID19 has 381653 nodes with 43 different node types:  the 5 most common are biolink:Publication (nodes number 129930), biolink:OntologyClass (nodes number 48937), biolink:Drug (nodes number 32148), biolink:ChemicalSubstance (nodes number 27433) and biolink:Disease (nodes number 24355), of which 8845 are singletons (41 of these have self-loops), and 15485798 unweighted edges with 34 different edge types:  the 5 most common are biolink:related_to, biolink:interacts_with, biolink:subclass_of, biolink:part_of and biolink:enables, of which 504 are self-loops and 2752 are parallel. The graph is quite sparse as it has a density of 0.00021 and has 9565 connected components, where the component with most nodes has 369141 nodes and the component with the least nodes has a single node. The graph median node degree is 6, the mean node degree is 81.15 and the node degree mode is 1. The top 5 most central nodes are MESH:D014780 (degree 90378), MESH:D006801 (degree 78249), WD:Q30 (degree 65223), MESH:D014777 (degree 54155) and MESH:D017934 (degree 45196).</p>"
+      ],
+      "text/plain": [
+       "The undirected multigraph KG-COVID19 has 381653 nodes with 43 different node types:  the 5 most common are biolink:Publication (nodes number 129930), biolink:OntologyClass (nodes number 48937), biolink:Drug (nodes number 32148), biolink:ChemicalSubstance (nodes number 27433) and biolink:Disease (nodes number 24355), of which 8845 are singletons (41 of these have self-loops), and 15485798 unweighted edges with 34 different edge types:  the 5 most common are biolink:related_to, biolink:interacts_with, biolink:subclass_of, biolink:part_of and biolink:enables, of which 504 are self-loops and 2752 are parallel. The graph is quite sparse as it has a density of 0.00021 and has 9565 connected components, where the component with most nodes has 369141 nodes and the component with the least nodes has a single node. The graph median node degree is 6, the mean node degree is 81.15 and the node degree mode is 1. The top 5 most central nodes are MESH:D014780 (degree 90378), MESH:D006801 (degree 78249), WD:Q30 (degree 65223), MESH:D014777 (degree 54155) and MESH:D017934 (degree 45196)."
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "KGCOVID19()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
With this pull request, we are introducing support for the automatic retrieval of all the graphs hosted in [kghub](https://kg-hub.berkeleybop.io/kg-covid-19/current/transformed/index.html). @justaddcoffee could you give the docstrings of the [`kg_hub.py`](https://github.com/AnacletoLAB/ensmallen_graph/blob/21de1b56a2f3ecfbf01ec2eb33d0b4c03b45ad91/bindings/python/ensmallen_graph/datasets/kg_hub.py) file to add some notes as needed?